### PR TITLE
Get integration tests working, fix native image build, update quarkus

### DIFF
--- a/backend-base/pom.xml
+++ b/backend-base/pom.xml
@@ -233,17 +233,13 @@
             <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
           </systemProperties>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-failsafe-plugin</artifactId>
-        <version>3.0.0-M4</version>
         <executions>
           <execution>
+            <id>integration-test</id>
             <goals>
-              <goal>integration-test</goal>
-              <goal>verify</goal>
+              <goal>test</goal>
             </goals>
+            <phase>integration-test</phase>
             <configuration>
               <excludes>
                 <exclude>**/Native*IT.java</exclude>

--- a/backend-base/pom.xml
+++ b/backend-base/pom.xml
@@ -17,7 +17,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <maven.compiler.parameters>true</maven.compiler.parameters>
     <surefire-plugin.version>2.22.0</surefire-plugin.version>
-    <quarkus.version>1.0.0.Final</quarkus.version>
+    <quarkus.version>1.2.0.Final</quarkus.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>

--- a/backend-base/pom.xml
+++ b/backend-base/pom.xml
@@ -75,7 +75,7 @@
       <exclusions>
         <exclusion>
           <groupId>org.eclipse.che.core</groupId>
-          <artifactId>che-core-api-dto</artifactId>
+          <artifactId>he-core-api-dto</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -149,6 +149,10 @@
         <exclusion>
           <groupId>org.eclipse.che.core</groupId>
           <artifactId>che-core-commons-schedule</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>javax.ws.rs</groupId>
+          <artifactId>javax.ws.rs-api</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/backend-base/src/main/java/org/eclipse/che/incubator/workspace/telemetry/TelemetryResource.java
+++ b/backend-base/src/main/java/org/eclipse/che/incubator/workspace/telemetry/TelemetryResource.java
@@ -24,52 +24,53 @@ import java.util.stream.Collectors;
 @ApplicationScoped
 public class TelemetryResource {
 
-    @Inject
-    AbstractAnalyticsManager analyticsManager;
+  @Inject
+  AbstractAnalyticsManager analyticsManager;
 
-    @POST
-    @Path("/event")
-    @Consumes(MediaType.APPLICATION_JSON)
-    @Produces(MediaType.TEXT_PLAIN)
-    @Operation(summary = "Posts a telemetry event",
+  @POST
+  @Path("/event")
+  @Consumes(MediaType.APPLICATION_JSON)
+  @Produces(MediaType.TEXT_PLAIN)
+  @Operation(summary = "Posts a telemetry event",
     description = "Submit telemetry events to the workspace telemetry manager.\nThe event Id should be the Id of a built-in event or of an alread-registered custom event",
     operationId = "event")
-    @APIResponse(responseCode = "200", description = "Event was successfully submitted")
-    @APIResponse(responseCode = "400", description = "Error during event submission")
-    public String event(
-        @RequestBody(
-            description = "Event to send",
-            required = true)
-        Event event) {
-            Map<String, Object> params =
-                event.getProperties().stream()
-                .collect(Collectors.toMap(e->e.getId(), e->e.getValue()));
+  @APIResponse(responseCode = "200", description = "Event was successfully submitted")
+  @APIResponse(responseCode = "400", description = "Error during event submission")
+  public String event(
+    @RequestBody(
+      description = "Event to send",
+      required = true)
+      Event event) {
+    Map<String, Object> params =
+      event.getProperties().stream()
+        .collect(Collectors.toMap(e -> e.getId(), e -> e.getValue()));
 
-                analyticsManager.onActivity();
-                analyticsManager.onEvent(AnalyticsEvent.valueOf(event.getId()), event.getOwnerId(), event.getIp(), event.getAgent(), event.getResolution(), params);
-                return "";
-      }
+    analyticsManager.onActivity();
+    analyticsManager.onEvent(AnalyticsEvent.valueOf(event.getId()), event.getOwnerId(), event.getIp(), event.getAgent(), event.getResolution(), params);
+    return "";
+  }
 
-    @POST
-    @Path("/activity")
-    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
-    @Produces(MediaType.TEXT_PLAIN)
-    @Operation(summary = "Notifies that some activity is still occuring from a given user",
+  @POST
+  @Path("/activity")
+  @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+  @Produces(MediaType.TEXT_PLAIN)
+  @Operation(summary = "Notifies that some activity is still occuring from a given user",
     description = "Notifies that some activity is still occuring for a given user. This will allow maintaining the current session alive for telemetry backends that manage user sessions.",
     operationId = "activity")
-    @APIResponse(responseCode = "200", description = "Notification was successfully submitted")
-    public String activity() {
-        analyticsManager.onActivity();
-        return "";
-    }
+  @APIResponse(responseCode = "200", description = "Notification was successfully submitted")
+  public String activity() {
+    System.out.println("Hi");
+    analyticsManager.onActivity();
+    return "";
+  }
 
-    void onStart(@Observes StartupEvent ev) {
-        // Just to trigger the injection of the
-        // analytics manager at start, so that initialization
-        // errors can be thrown at start.
-    }
+  void onStart(@Observes StartupEvent ev) {
+    // Just to trigger the injection of the
+    // analytics manager at start, so that initialization
+    // errors can be thrown at start.
+  }
 
-    void onStop(@Observes ShutdownEvent ev) {
-        analyticsManager.destroy();
-    }
+  void onStop(@Observes ShutdownEvent ev) {
+    analyticsManager.destroy();
+  }
 }

--- a/backend-base/src/main/java/org/eclipse/che/incubator/workspace/telemetry/generate/GenerateOpenApiSchema.java
+++ b/backend-base/src/main/java/org/eclipse/che/incubator/workspace/telemetry/generate/GenerateOpenApiSchema.java
@@ -3,6 +3,9 @@ package org.eclipse.che.incubator.workspace.telemetry.generate;
 import java.io.FileWriter;
 import java.io.IOException;
 
+import io.smallrye.config.SmallRyeConfig;
+import io.smallrye.config.SmallRyeConfigBuilder;
+import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.openapi.models.OpenAPI;
 import org.jboss.jandex.Index;
@@ -19,7 +22,12 @@ public class GenerateOpenApiSchema {
     System.setProperty(OpenApiConstants.SCHEMA_REFERENCES_ENABLE, "true");
     IndexReader indexReader = new IndexReader(GenerateOpenApiSchema.class.getClassLoader().getResourceAsStream("META-INF/jandex.idx"));
     Index index = indexReader.read();
-    OpenAPI openAPI = new OpenApiAnnotationScanner(new OpenApiConfigImpl(ConfigProvider.getConfig()), index).scan();
+    Config config = new SmallRyeConfigBuilder()
+      .addDefaultSources()
+      .addDiscoveredConverters()
+      .addDiscoveredSources()
+      .build();
+    OpenAPI openAPI = new OpenApiAnnotationScanner(new OpenApiConfigImpl(config), index).scan();
     String yaml = OpenApiSerializer.serialize(openAPI, Format.YAML);
     FileWriter fileWriter = new FileWriter(args[0]);
     fileWriter.write(yaml);

--- a/backend-base/src/test/java/org/eclipse/che/incubator/workspace/telemetry/TelemetryResourceIT.java
+++ b/backend-base/src/test/java/org/eclipse/che/incubator/workspace/telemetry/TelemetryResourceIT.java
@@ -16,11 +16,11 @@ import static org.hamcrest.Matchers.is;
 public class TelemetryResourceIT {
     @Test
     public void testEvent() {
-        ArrayList<EventProperty> properties = new ArrayList<EventProperty>();
+        ArrayList<EventProperty> properties = new ArrayList<>();
         Event e = new Event("WORKSPACE_STARTED", "1", "127.0.0.1", "curl", "", properties);
         given()
                 .when()
-                .contentType("application/json")
+                .contentType(MediaType.APPLICATION_JSON)
                 .body("{\"id\": \"WORKSPACE_STARTED\", \"userId\": \"admin\", \"ip\": \"127.0.0.1\"}")
                 .post("/telemetry/event")
                 .then()

--- a/backend-base/src/test/java/org/eclipse/che/incubator/workspace/telemetry/TelemetryResourceTest.java
+++ b/backend-base/src/test/java/org/eclipse/che/incubator/workspace/telemetry/TelemetryResourceTest.java
@@ -16,32 +16,34 @@ import static org.junit.jupiter.api.Assertions.*;
 @QuarkusTest
 public class TelemetryResourceTest {
 
-    @Inject
-    TelemetryResource telemetryResource;
+  @Inject
+  TelemetryResource telemetryResource;
 
-    @BeforeAll
-    public static void setUp() {
-        System.setProperty("che.api", "http://fake-che.com/api");
-        System.setProperty("che.workspace.id", "fake-workspace");
-    }
+  @BeforeAll
+  public static void setUp() {
+    System.setProperty("che.api", "http://fake-che.com/api");
+    System.setProperty("che.workspace.id", "fake-workspace");
+    System.setProperty("che.machine.token", "fake-token");
+  }
 
-    @AfterAll
-    public static void tesrDown() {
-        System.clearProperty("che.api");
-        System.clearProperty("che.workspace.id");
-    }
+  @AfterAll
+  public static void tearDown() {
+    System.clearProperty("che.api");
+    System.clearProperty("che.workspace.id");
+    System.clearProperty("che.machine.token");
+  }
 
-    @Test
-    public void testActivity() {
-        String response = telemetryResource.activity();
-        assertEquals("", response);
-    }
+  @Test
+  public void testActivity() {
+    String response = telemetryResource.activity();
+    assertEquals("", response);
+  }
 
-    @Test
-    public void testEvent() {
-        ArrayList<EventProperty> properties = new ArrayList<EventProperty>();
-        Event e = new Event("WORKSPACE_STARTED", "1", "127.0.0.1", "curl", "", properties);
-        String response = telemetryResource.event(e);
-        assertEquals("", response);
-    }
+  @Test
+  public void testEvent() {
+    ArrayList<EventProperty> properties = new ArrayList<>();
+    Event e = new Event("WORKSPACE_STARTED", "1", "127.0.0.1", "curl", "", properties);
+    String response = telemetryResource.event(e);
+    assertEquals("", response);
+  }
 }

--- a/backend-base/src/test/java/org/eclipse/che/incubator/workspace/telemetry/base/AbstractAnalyticsManagerTest.java
+++ b/backend-base/src/test/java/org/eclipse/che/incubator/workspace/telemetry/base/AbstractAnalyticsManagerTest.java
@@ -20,7 +20,7 @@ class AbstractAnalyticsManagerTest {
     public static void setUp() {
         System.setProperty("che.api", "https://fake-che.com/api");
         System.setProperty("che.workspace.id", "fake-workspace");
-        System.setProperty("che.machine.token", "");
+        System.setProperty("che.machine.token", "fake-token");
     }
 
     @AfterAll

--- a/backend-base/src/test/resources/application.properties
+++ b/backend-base/src/test/resources/application.properties
@@ -1,1 +1,4 @@
-
+# Configuration file
+# key = value
+quarkus.swagger-ui.always-include=true
+quarkus.ssl.native=true


### PR DESCRIPTION
This PR was to fix the double @ApplicationPath issue in https://github.com/redhat-developer/rh-che/issues/1748 but I ended up doing a few more cleanup things.  At the end of the day, I couldn't get it to work with the failsafe plugin, but looking at older versions of the code, we had it working with the surefire plugin, so that is what I did. 


- add an `integration-test` phase that uses the surefire plugin
- set fake machine tokens in tests (I feel like setting environment variables is a bad pattern for tests, maybe these should be additional properties in the test phase of the POM)
- add the SSL and swagger UI config options
- explicitly build the `SmallRyeConfig` for `GenerateOpenAPISchema`
- exclude a transitive dependency to get native image building working again
- update quarkus to 1.2.0-Final
