### PR TITLE
Add a list of plug-in names to the AnalyticsManager

### DIFF
--- a/backend-base/src/main/java/org/eclipse/che/incubator/workspace/telemetry/TelemetryResource.java
+++ b/backend-base/src/main/java/org/eclipse/che/incubator/workspace/telemetry/TelemetryResource.java
@@ -59,7 +59,6 @@ public class TelemetryResource {
     operationId = "activity")
   @APIResponse(responseCode = "200", description = "Notification was successfully submitted")
   public String activity() {
-    System.out.println("Hi");
     analyticsManager.onActivity();
     return "";
   }

--- a/backend-base/src/main/java/org/eclipse/che/incubator/workspace/telemetry/base/EventProperties.java
+++ b/backend-base/src/main/java/org/eclipse/che/incubator/workspace/telemetry/base/EventProperties.java
@@ -31,6 +31,7 @@ public interface EventProperties {
   public static final String OSIO_SPACE_ID = "osio space id";
   public static final String SOURCE_TYPES = "source types";
   public static final String START_NUMBER = "start number";
-  
+  public static final String PLUGINS = "plugins";
+
   public static final String[] values = {"", ""};
 }

--- a/backend-base/src/main/java/org/eclipse/che/incubator/workspace/telemetry/model/EventProperty.java
+++ b/backend-base/src/main/java/org/eclipse/che/incubator/workspace/telemetry/model/EventProperty.java
@@ -8,9 +8,7 @@ package org.eclipse.che.incubator.workspace.telemetry.model;
 
 import java.util.Objects;
 
-import org.eclipse.che.incubator.workspace.telemetry.base.AnalyticsEvent;
 import org.eclipse.che.incubator.workspace.telemetry.base.EventProperties;
-import org.eclipse.microprofile.openapi.annotations.ExternalDocumentation;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 @Schema(
@@ -76,7 +74,7 @@ public class EventProperty {
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class EventProperty {\n");
-    
+
     sb.append("    id: ").append(toIndentedString(id)).append("\n");
     sb.append("    value: ").append(toIndentedString(value)).append("\n");
     sb.append("}");


### PR DESCRIPTION
Adds a list of plugin names to the `AbstractAnalyticsManager` to track the plugins installed in woopra.

Part of https://github.com/eclipse/che/issues/16105

Signed-off-by: Tom George <tgeorge@redhat.com>