### PR TITLE
CRT-1149 Using SHA-1 hash algorithm for userId generation based on the username

### DIFF
--- a/backend-base/src/main/java/org/eclipse/che/incubator/workspace/telemetry/TelemetryApplication.java
+++ b/backend-base/src/main/java/org/eclipse/che/incubator/workspace/telemetry/TelemetryApplication.java
@@ -1,15 +1,23 @@
+/*
+ * Copyright (c) 2021 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
 package org.eclipse.che.incubator.workspace.telemetry;
 
 import javax.ws.rs.ApplicationPath;
 import javax.ws.rs.core.Application;
 
-import org.eclipse.che.incubator.workspace.telemetry.model.EventProperty;
-import org.eclipse.microprofile.openapi.annotations.Components;
 import org.eclipse.microprofile.openapi.annotations.OpenAPIDefinition;
 import org.eclipse.microprofile.openapi.annotations.info.Contact;
 import org.eclipse.microprofile.openapi.annotations.info.Info;
 import org.eclipse.microprofile.openapi.annotations.info.License;
-import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 @OpenAPIDefinition(
     info = @Info(

--- a/backend-base/src/main/java/org/eclipse/che/incubator/workspace/telemetry/TelemetryResource.java
+++ b/backend-base/src/main/java/org/eclipse/che/incubator/workspace/telemetry/TelemetryResource.java
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) 2021 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
 package org.eclipse.che.incubator.workspace.telemetry;
 
 import io.quarkus.runtime.ShutdownEvent;

--- a/backend-base/src/main/java/org/eclipse/che/incubator/workspace/telemetry/anonymizer/SHA1HashGenerator.java
+++ b/backend-base/src/main/java/org/eclipse/che/incubator/workspace/telemetry/anonymizer/SHA1HashGenerator.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2012-2021 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.incubator.workspace.telemetry.anonymizer;
+
+import static org.slf4j.LoggerFactory.getLogger;
+
+import java.io.UnsupportedEncodingException;
+import java.math.BigInteger;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+import javax.inject.Singleton;
+
+import org.slf4j.Logger;
+
+@Singleton
+public class SHA1HashGenerator {
+    private static final Logger LOG = getLogger(SHA1HashGenerator.class);
+    private static final String SHA_1 = "SHA-1";
+    private static final String UTF_8 = "utf8";
+    private static final String HEX= "%040x";
+
+    public String generateHash(final String input) {
+        String hash = null;
+        MessageDigest digest;
+        try {
+            digest = MessageDigest.getInstance(SHA_1);
+            digest.reset();
+            digest.update(input.getBytes(UTF_8));
+            hash = String.format(HEX, new BigInteger(1, digest.digest()));
+        } catch (NoSuchAlgorithmException | UnsupportedEncodingException e) {
+            LOG.error("Can not generate hash due to missing algorithm or unsupported encoding", e);
+        }
+        return hash;
+    }
+
+}

--- a/backend-base/src/main/java/org/eclipse/che/incubator/workspace/telemetry/base/AnalyticsEvent.java
+++ b/backend-base/src/main/java/org/eclipse/che/incubator/workspace/telemetry/base/AnalyticsEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 Red Hat, Inc.
+ * Copyright (c) 2016-2021 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/backend-base/src/main/java/org/eclipse/che/incubator/workspace/telemetry/base/BaseConfiguration.java
+++ b/backend-base/src/main/java/org/eclipse/che/incubator/workspace/telemetry/base/BaseConfiguration.java
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) 2021 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
 package org.eclipse.che.incubator.workspace.telemetry.base;
 
 import javax.enterprise.context.Dependent;

--- a/backend-base/src/main/java/org/eclipse/che/incubator/workspace/telemetry/base/DefaultAnalyticsManager.java
+++ b/backend-base/src/main/java/org/eclipse/che/incubator/workspace/telemetry/base/DefaultAnalyticsManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 Red Hat, Inc.
+ * Copyright (c) 2016-2021 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -40,7 +40,7 @@ public class DefaultAnalyticsManager extends AbstractAnalyticsManager {
 
   @Override
   public void onEvent(AnalyticsEvent event, String ownerId, String ip,
-      String userAgent, String resolution, Map<String, Object> properties) {
+    String userAgent, String resolution, Map<String, Object> properties) {
     LOG.info("Event triggered by user {} in {} from ip {} on agent {} :\n{}\nwith resolution: {}\nwith properties:\n{}", getUserId(), ownerId, ip, userAgent, event, resolution, properties);
   }
 

--- a/backend-base/src/main/java/org/eclipse/che/incubator/workspace/telemetry/base/EventProperties.java
+++ b/backend-base/src/main/java/org/eclipse/che/incubator/workspace/telemetry/base/EventProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 Red Hat, Inc.
+ * Copyright (c) 2016-2021 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/backend-base/src/main/java/org/eclipse/che/incubator/workspace/telemetry/generate/GenerateOpenApiSchema.java
+++ b/backend-base/src/main/java/org/eclipse/che/incubator/workspace/telemetry/generate/GenerateOpenApiSchema.java
@@ -1,12 +1,21 @@
+/*
+ * Copyright (c) 2021 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
 package org.eclipse.che.incubator.workspace.telemetry.generate;
 
 import java.io.FileWriter;
 import java.io.IOException;
 
-import io.smallrye.config.SmallRyeConfig;
 import io.smallrye.config.SmallRyeConfigBuilder;
 import org.eclipse.microprofile.config.Config;
-import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.openapi.models.OpenAPI;
 import org.jboss.jandex.Index;
 import org.jboss.jandex.IndexReader;

--- a/backend-base/src/main/java/org/eclipse/che/incubator/workspace/telemetry/graalvm/RuntimeReflectionRegistrationFeature.java
+++ b/backend-base/src/main/java/org/eclipse/che/incubator/workspace/telemetry/graalvm/RuntimeReflectionRegistrationFeature.java
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) 2021 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
 package org.eclipse.che.incubator.workspace.telemetry.graalvm;
 
 import java.lang.reflect.Constructor;

--- a/backend-base/src/main/java/org/eclipse/che/incubator/workspace/telemetry/model/Event.java
+++ b/backend-base/src/main/java/org/eclipse/che/incubator/workspace/telemetry/model/Event.java
@@ -14,7 +14,6 @@ package org.eclipse.che.incubator.workspace.telemetry.model;
 
 import java.util.Objects;
 
-import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 import java.util.ArrayList;

--- a/backend-base/src/test/java/org/eclipse/che/incubator/workspace/telemetry/MockHttpJsonResponse.java
+++ b/backend-base/src/test/java/org/eclipse/che/incubator/workspace/telemetry/MockHttpJsonResponse.java
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) 2021 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
 package org.eclipse.che.incubator.workspace.telemetry;
 
 import com.google.gson.reflect.TypeToken;

--- a/backend-base/src/test/java/org/eclipse/che/incubator/workspace/telemetry/NativeTelemetryResourceIT.java
+++ b/backend-base/src/test/java/org/eclipse/che/incubator/workspace/telemetry/NativeTelemetryResourceIT.java
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) 2021 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
 package org.eclipse.che.incubator.workspace.telemetry;
 
 import io.quarkus.test.junit.NativeImageTest;

--- a/backend-base/src/test/java/org/eclipse/che/incubator/workspace/telemetry/TelemetryResourceIT.java
+++ b/backend-base/src/test/java/org/eclipse/che/incubator/workspace/telemetry/TelemetryResourceIT.java
@@ -1,7 +1,17 @@
+/*
+ * Copyright (c) 2021 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
 package org.eclipse.che.incubator.workspace.telemetry;
 
 import io.quarkus.test.junit.QuarkusTest;
-import io.restassured.RestAssured;
 import org.eclipse.che.incubator.workspace.telemetry.model.Event;
 import org.eclipse.che.incubator.workspace.telemetry.model.EventProperty;
 import org.junit.jupiter.api.Test;
@@ -10,7 +20,6 @@ import javax.ws.rs.core.MediaType;
 import java.util.ArrayList;
 
 import static io.restassured.RestAssured.*;
-import static org.hamcrest.Matchers.is;
 
 @QuarkusTest
 public class TelemetryResourceIT {

--- a/backend-base/src/test/java/org/eclipse/che/incubator/workspace/telemetry/TelemetryResourceTest.java
+++ b/backend-base/src/test/java/org/eclipse/che/incubator/workspace/telemetry/TelemetryResourceTest.java
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) 2021 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
 package org.eclipse.che.incubator.workspace.telemetry;
 
 import io.quarkus.test.junit.QuarkusTest;

--- a/backend-base/src/test/java/org/eclipse/che/incubator/workspace/telemetry/anonymizer/SHA1HashGeneratorTest.java
+++ b/backend-base/src/test/java/org/eclipse/che/incubator/workspace/telemetry/anonymizer/SHA1HashGeneratorTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2012-2021 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.incubator.workspace.telemetry.anonymizer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class SHA1HashGeneratorTest {
+    private static final String TEST_USERNAME= "test-username";
+    private static final String EXPECTED_SHA1_HASH= "ded736438647e25487ef37c6c6ca2420ef0072db";
+
+    @Test
+    public void testHashGeneration() {
+        String hash = new SHA1HashGenerator().generateHash(TEST_USERNAME);
+        assertEquals(hash, EXPECTED_SHA1_HASH);
+    }
+
+}

--- a/backend-base/src/test/java/org/eclipse/che/incubator/workspace/telemetry/base/AbstractAnalyticsManagerTest.java
+++ b/backend-base/src/test/java/org/eclipse/che/incubator/workspace/telemetry/base/AbstractAnalyticsManagerTest.java
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) 2021 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
 package org.eclipse.che.incubator.workspace.telemetry.base;
 
 import io.quarkus.test.junit.QuarkusTest;

--- a/backend-base/src/test/java/org/eclipse/che/incubator/workspace/telemetry/base/MockBaseConfiguration.java
+++ b/backend-base/src/test/java/org/eclipse/che/incubator/workspace/telemetry/base/MockBaseConfiguration.java
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) 2021 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
 package org.eclipse.che.incubator.workspace.telemetry.base;
 
 import io.quarkus.test.Mock;


### PR DESCRIPTION
- [x]  Using SHA-1 hash algorithm for userId generation based on the username
- [x] Adding license headers
- [x] Minor refactoring / removing unused imports

Signed-off-by: Ilya Buziuk <ibuziuk@redhat.com>