### PR TITLE
che #20716 swithing 'moxios' dependency to the 'github:' protocol

### DIFF
--- a/javascript/src/typescript/package.json
+++ b/javascript/src/typescript/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@eclipse-che/api": "^7.3.2",
     "axios": "0.21.2",
-    "moxios": "git://github.com/stoplightio/moxios#v1.3.0"
+    "moxios": "github:stoplightio/moxios#v1.3.0"
   },
   "devDependencies": {
     "@types/jest": "22.1.3",

--- a/javascript/src/typescript/yarn.lock
+++ b/javascript/src/typescript/yarn.lock
@@ -3739,9 +3739,9 @@ move-concurrently@^1.0.1:
     rimraf "^2.5.4"
     run-queue "^1.0.3"
 
-"moxios@git://github.com/stoplightio/moxios#v1.3.0":
+"moxios@github:stoplightio/moxios#v1.3.0":
   version "1.3.0"
-  resolved "git://github.com/stoplightio/moxios#9d702c8eafee4b02917d6bc400ae15f1e835cf51"
+  resolved "https://codeload.github.com/stoplightio/moxios/tar.gz/9d702c8eafee4b02917d6bc400ae15f1e835cf51"
   dependencies:
     class-autobind "^0.1.4"
 


### PR DESCRIPTION
Signed-off-by: Ilya Buziuk <ibuziuk@redhat.com>

Should fix https://github.com/eclipse/che/issues/20716

`git://` protocol is not supported anymore for unauthenticated GitHub requests
https://github.blog/2021-09-01-improving-git-protocol-security-github/#no-more-unauthenticated-git