### PR TITLE
fix: add lastOwnerId field

### DIFF
--- a/backend-base/src/main/java/org/eclipse/che/incubator/workspace/telemetry/base/AbstractAnalyticsManager.java
+++ b/backend-base/src/main/java/org/eclipse/che/incubator/workspace/telemetry/base/AbstractAnalyticsManager.java
@@ -79,6 +79,8 @@ public abstract class AbstractAnalyticsManager {
 
   protected long lastEventTime;
 
+  protected String lastOwnerId = null;
+
   protected String lastIp = null;
 
   protected String lastUserAgent = null;
@@ -159,6 +161,7 @@ public abstract class AbstractAnalyticsManager {
       onEvent(event, ownerId, ip, userAgent, resolution, getCurrentEventProperties(properties));
       lastEvent = event;
       lastEventTime = System.currentTimeMillis();
+      lastOwnerId = ownerId;
       lastIp = ip;
       lastUserAgent = userAgent;
       lastResolution = resolution;

--- a/backend-base/src/test/java/org/eclipse/che/incubator/workspace/telemetry/NativeTelemetryResourceIT.java
+++ b/backend-base/src/test/java/org/eclipse/che/incubator/workspace/telemetry/NativeTelemetryResourceIT.java
@@ -27,7 +27,6 @@ public class NativeTelemetryResourceIT extends TelemetryResourceTest {
     @Test
     public void testEvent() {
         ArrayList<EventProperty> properties = new ArrayList<EventProperty>();
-        Event e = new Event("WORKSPACE_STARTED", "1", "127.0.0.1", "curl", "", properties);
         given()
                 .when()
                 .contentType("application/json")

--- a/backend-base/src/test/java/org/eclipse/che/incubator/workspace/telemetry/base/AbstractAnalyticsManagerTest.java
+++ b/backend-base/src/test/java/org/eclipse/che/incubator/workspace/telemetry/base/AbstractAnalyticsManagerTest.java
@@ -12,12 +12,14 @@
 package org.eclipse.che.incubator.workspace.telemetry.base;
 
 import io.quarkus.test.junit.QuarkusTest;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import javax.inject.Inject;
 
+import java.util.Collections;
+import java.util.Map;
+
+import static java.util.Map.entry;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -41,4 +43,24 @@ class AbstractAnalyticsManagerTest {
         assertEquals(86763L, analyticsManager.age);
     }
 
+    @Test
+    public void testLastEventDataIsStored() {
+      AnalyticsEvent event = AnalyticsEvent.WORKSPACE_OPENED;
+      String ownerId = "/default-theia-plugins/telemetry_plugin";
+      String ip = "192.0.0.0";
+      String userAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)";
+      String resolution = "2560x1440";
+      Map<String, Object> properties = Map.ofEntries(
+        entry("custom property", "foobar")
+      );
+
+      analyticsManager.doSendEvent(event, ownerId, ip, userAgent, resolution, properties);
+
+      assertEquals(event, analyticsManager.lastEvent);
+      assertEquals(ip, analyticsManager.lastIp);
+      assertEquals(ownerId, analyticsManager.lastOwnerId);
+      assertEquals(userAgent, analyticsManager.lastUserAgent);
+      assertEquals(resolution, analyticsManager.lastResolution);
+      assertEquals(properties, analyticsManager.lastEventProperties);
+    }
 }


### PR DESCRIPTION
The Che docs example code [1] uses the `lastOwnerId` field, however, this field does not exist in `AbstractAnalyticsManager`.

[1] https://www.eclipse.org/che/docs/che-7/extensions/creating-a-telemetry-plugin/#_implementing_onactivity

This PR adds the `lastOwnerId` field.

Signed-off-by: David Kwon <dakwon@redhat.com>