### PR TITLE
fix: synchronize the lastEventTime update to prevent concurrent accesses

### DIFF
--- a/backend-base/README.md
+++ b/backend-base/README.md
@@ -6,6 +6,10 @@ This library is meant to be extended later by other libraries.  It implements a 
 * JDK 11+
 * Apache Maven 3.8.1+
 
+## Devworkspace telemetry support
+Since version backend-base version 0.0.33, Che server workspace telemetry support has been replaced in favour of DevWorkspace telemetry.
+Version 0.0.32 is the latest version supporting Che server workspace telemetry.
+
 ## Building
 
 Be sure to set `devworkspace.id` in `src/main/resources/application.properties` or set it on the command line during the maven run:
@@ -31,25 +35,6 @@ mvn test
 
 ###  Native-mode integration testing
 
-#### Prerequisites
-
-+ A Running Che Cluster in CRC, Minikube, Kind, etc.
-+ A devworkspace ID of a devworkspace in the cluster
-
-In the `src/main/resources/application.properties` file, add:
-```
-%test.devworkspace.id=<devworkspace ID>
-```
-
-Then run:
 ```shell script
-kubectl config set-context --current --namespace=<namespace that the devworkspace is in>
 mvn verify -Pnative -Dquarkus.test.native-image-profile=test
-```
-
-To run the native integration tests with the native image already built, run:
-```shell script
-export DEVWORKSPACE_ID=<devworkspace ID>
-mvn test-compile failsafe:integration-test
-unset DEVWORKSPACE_ID
 ```

--- a/backend-base/src/test/java/org/eclipse/che/incubator/workspace/telemetry/base/AbstractAnalyticsManagerTest.java
+++ b/backend-base/src/test/java/org/eclipse/che/incubator/workspace/telemetry/base/AbstractAnalyticsManagerTest.java
@@ -12,55 +12,162 @@
 package org.eclipse.che.incubator.workspace.telemetry.base;
 
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.mockito.InjectSpy;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
-import javax.inject.Inject;
-
-import java.util.Collections;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import static java.util.Map.entry;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 
 @QuarkusTest
 class AbstractAnalyticsManagerTest {
 
-    @Inject
-    AbstractAnalyticsManager analyticsManager;
+  @InjectSpy
+  AbstractAnalyticsManager analyticsManager;
 
-    @Test
-    public void testInstantiation() {
-        assertNotNull(analyticsManager);
+  @BeforeEach
+  public void init() {
+    clearLastEvent();
+    Mockito.clearInvocations(analyticsManager);
+  }
+
+  @Test
+  public void testInstantiation() {
+    assertNotNull(analyticsManager);
+  }
+
+  @Test
+  public void testMockResponseProperties() {
+    assertEquals("fake-devworkspace", analyticsManager.devworkspaceId);
+    assertEquals("python-hello-world", analyticsManager.devworkspaceName);
+    assertEquals(1644869222000L, analyticsManager.createdOn);
+    assertEquals(1644955985435L, analyticsManager.updatedOn);
+    assertEquals(86763L, analyticsManager.age);
+  }
+
+  @Test
+  public void testLastEventDataIsStored() {
+    AnalyticsEvent event = AnalyticsEvent.WORKSPACE_OPENED;
+    String ownerId = "/default-theia-plugins/telemetry_plugin";
+    String ip = "192.0.0.0";
+    String userAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)";
+    String resolution = "2560x1440";
+    Map<String, Object> properties = Map.ofEntries(
+      entry("custom property", "foobar")
+    );
+
+    analyticsManager.doSendEvent(event, ownerId, ip, userAgent, resolution, properties);
+
+    assertEquals(event, analyticsManager.getLastEvent());
+    assertEquals(ip, analyticsManager.getLastIp());
+    assertEquals(ownerId, analyticsManager.getLastOwnerId());
+    assertEquals(userAgent, analyticsManager.getLastUserAgent());
+    assertEquals(resolution, analyticsManager.getLastResolution());
+    assertEquals(properties, analyticsManager.getLastEventProperties());
+  }
+
+  @Test
+  public void testIdenticalEventsMergedSerial() throws InterruptedException {
+    AnalyticsEvent event = AnalyticsEvent.WORKSPACE_STARTED;
+    String ownerId = "/default-theia-plugins/telemetry_plugin";
+    String ip = "192.0.0.0";
+    String userAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)";
+    String resolution = "2560x1440";
+
+    for (int i = 0; i < 10; i++) {
+      analyticsManager.doSendEvent(event, ownerId, ip, userAgent, resolution);
     }
+    Mockito.verify(analyticsManager, Mockito.times(1)).onEvent(any(), any(), any(), any(), any(), any());
+  }
 
-    @Test
-    public void testMockResponseProperties() {
-        assertEquals("fake-devworkspace", analyticsManager.devworkspaceId);
-        assertEquals("python-hello-world", analyticsManager.devworkspaceName);
-        assertEquals(1644869222000L, analyticsManager.createdOn);
-        assertEquals(1644955985435L, analyticsManager.updatedOn);
-        assertEquals(86763L, analyticsManager.age);
+
+  @Test
+  public void testIdenticalEventsMergedParallel() throws InterruptedException {
+    int numberOfThreads = 10;
+    ExecutorService service = Executors.newFixedThreadPool(numberOfThreads);
+    CountDownLatch latch = new CountDownLatch(numberOfThreads);
+
+    AnalyticsEvent event = AnalyticsEvent.WORKSPACE_STARTED;
+    String ownerId = "/default-theia-plugins/telemetry_plugin";
+    String ip = "192.0.0.0";
+    String userAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)";
+    String resolution = "2560x1440";
+
+    for (int i = 0; i < numberOfThreads; i++) {
+      service.execute(() -> {
+        analyticsManager.doSendEvent(event, ownerId, ip, userAgent, resolution);
+        latch.countDown();
+      });
     }
+    latch.await();
+    Mockito.verify(analyticsManager, Mockito.times(1)).onEvent(any(), any(), any(), any(), any(), any());
+  }
 
-    @Test
-    public void testLastEventDataIsStored() {
-      AnalyticsEvent event = AnalyticsEvent.WORKSPACE_OPENED;
-      String ownerId = "/default-theia-plugins/telemetry_plugin";
-      String ip = "192.0.0.0";
-      String userAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)";
-      String resolution = "2560x1440";
-      Map<String, Object> properties = Map.ofEntries(
-        entry("custom property", "foobar")
-      );
+  @Test
+  public void testDifferentEventsNotMerged() throws InterruptedException {
+    int numberOfThreads = 6;
+    ExecutorService service = Executors.newFixedThreadPool(numberOfThreads);
+    CountDownLatch latch = new CountDownLatch(numberOfThreads);
 
-      analyticsManager.doSendEvent(event, ownerId, ip, userAgent, resolution, properties);
+    AnalyticsEvent[] events = new AnalyticsEvent[]{
+      AnalyticsEvent.WORKSPACE_STARTED,
+      AnalyticsEvent.WORKSPACE_INACTIVE,
+      AnalyticsEvent.WORKSPACE_STOPPED,
+      AnalyticsEvent.EDITOR_USED,
+      AnalyticsEvent.PUSH_TO_REMOTE,
+      AnalyticsEvent.COMMIT_LOCALLY,
+    };
 
-      assertEquals(event, analyticsManager.lastEvent);
-      assertEquals(ip, analyticsManager.lastIp);
-      assertEquals(ownerId, analyticsManager.lastOwnerId);
-      assertEquals(userAgent, analyticsManager.lastUserAgent);
-      assertEquals(resolution, analyticsManager.lastResolution);
-      assertEquals(properties, analyticsManager.lastEventProperties);
+    String ownerId = "/default-theia-plugins/telemetry_plugin";
+    String ip = "192.0.0.0";
+    String userAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)";
+    String resolution = "2560x1440";
+
+    for (int i = 0; i < numberOfThreads; i++) {
+      AnalyticsEvent event = events[i];
+      service.execute(() -> {
+        analyticsManager.doSendEvent(event, ownerId, ip, userAgent, resolution);
+        latch.countDown();
+      });
     }
+    latch.await();
+    Mockito.verify(analyticsManager, Mockito.times(6)).onEvent(any(), any(), any(), any(), any(), any());
+  }
+
+  @Test
+  public void testMergeEventProperties() throws InterruptedException {
+    Map<String, Object> properties = Map.ofEntries(
+      entry("event property", "foobar")
+    );
+
+    Map<String, Object> mergedProperties = analyticsManager.getMergedEventProperties(properties);
+
+    assertEquals(6, mergedProperties.size());
+    assertTrue(mergedProperties.containsKey(EventProperties.CREATED));
+    assertTrue(mergedProperties.containsKey(EventProperties.DEVWORKSPACE_ID));
+    assertTrue(mergedProperties.containsKey(EventProperties.DEVWORKSPACE_NAME));
+    assertTrue(mergedProperties.containsKey(EventProperties.UPDATED));
+    assertTrue(mergedProperties.containsKey(EventProperties.AGE));
+
+    assertEquals("foobar", mergedProperties.get("event property"));
+    assertEquals(1644869222000L, mergedProperties.get(EventProperties.CREATED));
+    assertEquals("fake-devworkspace", mergedProperties.get(EventProperties.DEVWORKSPACE_ID));
+    assertEquals("python-hello-world", mergedProperties.get(EventProperties.DEVWORKSPACE_NAME));
+    assertEquals(1644955985435L, mergedProperties.get(EventProperties.UPDATED));
+    assertEquals(86763L, mergedProperties.get(EventProperties.AGE));
+  }
+
+  private void clearLastEvent() {
+    // send a dummy event to overwrite previous event
+    analyticsManager.doSendEvent(null, null, null, null, null);
+  }
 }

--- a/backend-base/src/test/java/org/eclipse/che/incubator/workspace/telemetry/base/MockAnalyticsManager.java
+++ b/backend-base/src/test/java/org/eclipse/che/incubator/workspace/telemetry/base/MockAnalyticsManager.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2022 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.incubator.workspace.telemetry.base;
+
+import io.quarkus.test.Mock;
+import org.eclipse.che.incubator.workspace.telemetry.finder.DevWorkspaceFinder;
+import org.eclipse.che.incubator.workspace.telemetry.finder.UsernameFinder;
+import javax.enterprise.context.ApplicationScoped;
+import java.util.Map;
+
+@ApplicationScoped
+@Mock
+public class MockAnalyticsManager extends AbstractAnalyticsManager {
+  public MockAnalyticsManager(BaseConfiguration baseConfiguration, DevWorkspaceFinder devworkspaceFinder, UsernameFinder usernameFinder) {
+    super(baseConfiguration, devworkspaceFinder, usernameFinder);
+  }
+
+  @Override
+  public boolean isEnabled() {
+    return true;
+  }
+
+  @Override
+  public void onActivity() {
+
+  }
+
+  @Override
+  public void onEvent(AnalyticsEvent event, String ownerId, String ip, String userAgent, String resolution, Map<String, Object> properties) {
+
+  }
+
+  @Override
+  public void increaseDuration(AnalyticsEvent event, Map<String, Object> properties) {
+
+  }
+
+  @Override
+  public void destroy() {
+
+  }
+
+}


### PR DESCRIPTION
Should fix https://github.com/che-incubator/che-workspace-telemetry-client/issues/89

To test this PR, run `mvn test` to run all tests. This PR includes two tests that verifies that multiple `Start workspace in che in Che` events are merged: 

https://github.com/dkwon17/che-workspace-telemetry-client/blob/8c2fc58ed4f283851fb6139332700c88e0db8717/backend-base/src/test/java/org/eclipse/che/incubator/workspace/telemetry/base/AbstractAnalyticsManagerTest.java#L79

https://github.com/dkwon17/che-workspace-telemetry-client/blob/8c2fc58ed4f283851fb6139332700c88e0db8717/backend-base/src/test/java/org/eclipse/che/incubator/workspace/telemetry/base/AbstractAnalyticsManagerTest.java#L94
