### PR TITLE
Update version using ./update-versions.sh

### DIFF
--- a/backend-base/pom.xml
+++ b/backend-base/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.che.incubator.workspace-telemetry</groupId>
     <artifactId>parent</artifactId>
-    <version>0.0.36</version>
+    <version>0.0.37</version>
   </parent>
   <distributionManagement>
     <repository>
@@ -12,7 +12,7 @@
     </repository>
   </distributionManagement>
   <artifactId>backend-base</artifactId>
-  <version>0.0.36</version>
+  <version>0.0.37</version>
   <properties>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <maven.compiler.release>11</maven.compiler.release>

--- a/javascript/pom.xml
+++ b/javascript/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.che.incubator.workspace-telemetry</groupId>
     <artifactId>parent</artifactId>
-    <version>0.0.36</version>
+    <version>0.0.37</version>
   </parent>
   <distributionManagement>
     <repository>
@@ -12,13 +12,13 @@
     </repository>
   </distributionManagement>
   <artifactId>javascript</artifactId>
-  <version>0.0.36</version>
+  <version>0.0.37</version>
   <packaging>pom</packaging>
   <dependencies>
     <dependency>
       <groupId>org.eclipse.che.incubator.workspace-telemetry</groupId>
       <artifactId>backend-base</artifactId>
-      <version>0.0.36</version>
+      <version>0.0.37</version>
       <classifier>resources</classifier>
       <type>zip</type>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.eclipse.che.incubator.workspace-telemetry</groupId>
   <artifactId>parent</artifactId>
-  <version>0.0.36</version>
+  <version>0.0.37</version>
   <packaging>pom</packaging>
   <modules>
     <module>backend-base</module>
@@ -18,7 +18,7 @@
         <artifactId>backend-base</artifactId>
         <classifier>resources</classifier>
         <type>zip</type>
-        <version>0.0.36</version>
+        <version>0.0.37</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
On the master branch, it seems like the build is failing because version 0.0.37 is already published on GitHub packages: https://github.com/che-incubator/che-workspace-telemetry-client/packages/98373

The reason why 0.0.37 is already published even though the current version on master is [0.0.36](https://github.com/che-incubator/che-workspace-telemetry-client/blob/f0d37f118e7671d06c7f303874e573ebe15c0e94/pom.xml#L21) is because the update commit failed to push in the CI here: https://github.com/che-incubator/che-workspace-telemetry-client/runs/5689881244?check_suite_focus=true

<img width="916" alt="image" src="https://user-images.githubusercontent.com/83611742/170798165-836ec2fa-b414-4ecc-9087-a89769b8af8e.png">


It looks like we see
```
hint: Updates were rejected because the remote contains work that you do
```
in the CI logs linked above because there was another commit applied to master: 7fbfa275407c09acca289a03a31d004db7f310c2, which was applied before the CI (linked above ) could finish.

This PR updates the version from the three `pom.xml`s to 0.37, with the purpose of having the CI update the version once more to 0.38, so that the CI can publish maven artifacts to GitHub packages.